### PR TITLE
fix: input agora está selecionável

### DIFF
--- a/src/components/SectionFixed/styles.js
+++ b/src/components/SectionFixed/styles.js
@@ -1,11 +1,10 @@
 import styled from "styled-components";
 
 export const TitleFx = styled.Text`
-    margin-top: 12px;
     color: #252525;
     font-size: 28px;
     font-family: "Montserrat-500";
-    padding: 30% 0 0 3%;
+    margin: 35% 0 0 3%;
 `;
 
 export const FixContainer = styled.View`

--- a/src/components/SectionNotas/styles.js
+++ b/src/components/SectionNotas/styles.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 
 export const Title = styled.Text`
-    /* position:absolute; */
     color: #252525;
     font-size: 28px;
     font-family: 'Montserrat-500';
@@ -10,8 +9,6 @@ export const Title = styled.Text`
 
 
 export const NotesContainer = styled.View`
-    /* width: 100%; */
-    /* height: 100px; */
     position: relative;
     top: 0;
 `;


### PR DESCRIPTION
Devido ao _padding_ utilizado para dispor a sessão no local certo, a sessão sobrepos o input impossibilitando a seleção dele. Neste caso a melhor opção foi utilizar o margin para fazer o espaçamento sem prejudicar os demais componentes